### PR TITLE
05 - Historial de registros

### DIFF
--- a/src/application/app.module.ts
+++ b/src/application/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 
 import { ImcModule } from '../module/imc/imc.module';
 import { AppController } from './app.controller';
@@ -29,6 +29,7 @@ import { DatabaseModule } from '../module/database/database.module';
     ImcModule,
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [AppService, Logger],
+  exports: [Logger],
 })
 export class AppModule {}

--- a/src/application/app.module.ts
+++ b/src/application/app.module.ts
@@ -6,6 +6,8 @@ import { AppService } from './app.service';
 
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ConfigurationModule } from '../config/configuration.module';
+import { AuthModule } from '../module/auth/auth.module';
+import { DatabaseModule } from '../module/database/database.module';
 
 @Module({
   imports: [
@@ -13,18 +15,16 @@ import { ConfigurationModule } from '../config/configuration.module';
     // Configuración de TypeOrm
     TypeOrmModule.forRoot({
       type: 'postgres',
-      host: process.env.DB_HOST,
-      port: parseInt(process.env.DB_PORT!),
-      username: process.env.DB_USER,
-      password: process.env.DB_PASSWORD,
-      database: process.env.DB_NAME,
-      ssl: { rejectUnauthorized: false }, // obligatorio en Supabase
+      url: process.env.DATABASE_URL,
       autoLoadEntities: true,
-      synchronize: true,
+      synchronize: process.env.NODE_ENV === 'dev',
+      ssl: {
+        rejectUnauthorized: false,
+      },
     }),
     // Incluye módulos generales
-    // DatabaseModule,
-    // AuthModule,
+    DatabaseModule,
+    AuthModule,
     // Módulos del dominio
     ImcModule,
   ],

--- a/src/module/database/services/supabase.service.ts
+++ b/src/module/database/services/supabase.service.ts
@@ -10,8 +10,10 @@ export class SupabaseService {
   constructor(private readonly configService: ConfigService) {
     const supabaseConfig = this.configService.get<SupabaseConfig>('supabase');
 
-    if (!supabaseConfig?.url) throw new Error('SUPABASE_URL must be defined');
-    if (!supabaseConfig?.key) throw new Error('SUPABASE_KEY must be defined');
+    if (!supabaseConfig?.url)
+      throw new Error('SUPABASE_URL must be defined in configuration');
+    if (!supabaseConfig?.key)
+      throw new Error('SUPABASE_KEY must be defined in configuration');
 
     this.supabase = createClient(supabaseConfig.url, supabaseConfig.key);
   }

--- a/src/module/imc/application/requests/history-request.ts
+++ b/src/module/imc/application/requests/history-request.ts
@@ -1,0 +1,11 @@
+import { IsDateString, IsOptional } from 'class-validator';
+
+export class HistoryRequest {
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+}

--- a/src/module/imc/domain/models/imc-record.ts
+++ b/src/module/imc/domain/models/imc-record.ts
@@ -15,7 +15,7 @@ export class ImcRecord {
   @Column('float')
   imc: number;
 
-  @Column('date')
+  @Column('timestamptz')
   date: Date;
 
   @ManyToOne(() => Category, (category) => category.records, { eager: true })

--- a/src/module/imc/imc.module.ts
+++ b/src/module/imc/imc.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Logger, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { DatabaseModule } from '../database/database.module';
@@ -14,7 +14,7 @@ import { ImcController } from './presentation/api/imc.controller';
     AuthModule,
   ],
   controllers: [ImcController],
-  providers: [ImcService],
+  providers: [ImcService, Logger],
   exports: [ImcService],
 })
 export class ImcModule {}

--- a/src/module/imc/infrastructure/services/imc.service.ts
+++ b/src/module/imc/infrastructure/services/imc.service.ts
@@ -61,11 +61,35 @@ export class ImcService {
   }
 
   /**
-   * Get all IMC records from the database
+   * Get all IMC records from the database for a specific user and optional date range.
+   * @param userId string
+   * @param startDate Date | undefined
+   * @param endDate Date | undefined
    * @returns Promise<ImcRecord[]>
    * @fixme filter by user id
    */
-  async getRecords(userId: string): Promise<ImcRecord[]> {
-    return await this.imcRepository.find({ where: { userId } });
+  async getRecords(
+    userId: string,
+    startDate?: Date,
+    endDate?: Date,
+  ): Promise<ImcRecord[]> {
+    // Create the base query
+    const query = this.imcRepository
+      .createQueryBuilder('imc')
+      .where('imc.userId = :userId', { userId })
+      .leftJoinAndSelect('imc.category', 'category')
+      .orderBy('imc.date', 'ASC');
+
+    // Add date filters if provided
+    if (startDate) {
+      query.andWhere('imc.date >= :startDate', { startDate });
+    }
+
+    // Add date filters if provided
+    if (endDate) {
+      query.andWhere('imc.date <= :endDate', { endDate });
+    }
+
+    return await query.getMany();
   }
 }

--- a/src/module/imc/infrastructure/services/imc.service.ts
+++ b/src/module/imc/infrastructure/services/imc.service.ts
@@ -73,12 +73,17 @@ export class ImcService {
     startDate?: Date,
     endDate?: Date,
   ): Promise<ImcRecord[]> {
+    // Validate the cronology of the dates
+    if (startDate && endDate && startDate > endDate) {
+      throw new Error('The start date must be earlier than the end date.');
+    }
+
     // Create the base query
     const query = this.imcRepository
       .createQueryBuilder('imc')
       .where('imc.userId = :userId', { userId })
       .leftJoinAndSelect('imc.category', 'category')
-      .orderBy('imc.date', 'ASC');
+      .orderBy('imc.date', 'DESC');
 
     // Add date filters if provided
     if (startDate) {

--- a/src/module/imc/presentation/api/imc.controller.ts
+++ b/src/module/imc/presentation/api/imc.controller.ts
@@ -1,7 +1,10 @@
 import {
+  BadRequestException,
   Body,
   Controller,
+  Get,
   Post,
+  Query,
   UseGuards,
   ValidationPipe,
 } from '@nestjs/common';
@@ -9,6 +12,7 @@ import { User } from '@supabase/supabase-js';
 import { UserFromRequest } from '../../../auth/infrastructure/decorators/user.decorator';
 import { SupabaseAuthGuard } from '../../../auth/infrastructure/guard/supbase-auth.guard';
 import { CalcularImcRequest } from '../../application/requests/calcular-imc-request';
+import { HistoryRequest } from '../../application/requests/history-request';
 import { ImcService } from '../../infrastructure/services/imc.service';
 
 @Controller('imc')
@@ -25,9 +29,25 @@ export class ImcController {
     return this.imcService.calcularImc(data, userId);
   }
 
-  @Post('history')
+  @Get('history')
   @UseGuards(SupabaseAuthGuard)
-  async getHistory(@UserFromRequest() user: User) {
-    return await this.imcService.getRecords(user.id);
+  async getHistory(
+    @UserFromRequest() user: User,
+    @Query(ValidationPipe) query: HistoryRequest,
+  ) {
+    const { startDate, endDate } = query;
+
+    // Validate date range
+    if (startDate && endDate && new Date(startDate) > new Date(endDate)) {
+      throw new BadRequestException(
+        'Invalid date range: startDate is after endDate',
+      );
+    }
+
+    return await this.imcService.getRecords(
+      user.id,
+      startDate ? new Date(startDate) : undefined,
+      endDate ? new Date(endDate) : undefined,
+    );
   }
 }

--- a/test/database/supabase.service.spec.ts
+++ b/test/database/supabase.service.spec.ts
@@ -1,6 +1,8 @@
 import { ConfigModule } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { SupabaseService } from '../../src/module/database/services/supabase.service';
+import { ConfigTestProvider } from '../shared/providers/config-test.provider';
+import { SupabaseTestProvider } from '../shared/providers/supabase-config-test.provider';
 
 describe('SupabaseService', () => {
   let service: SupabaseService;
@@ -12,7 +14,7 @@ describe('SupabaseService', () => {
 
     const module: TestingModule = await Test.createTestingModule({
       imports: [ConfigModule],
-      providers: [SupabaseService],
+      providers: [SupabaseService, SupabaseTestProvider, ConfigTestProvider],
     }).compile();
 
     service = module.get<SupabaseService>(SupabaseService);
@@ -28,10 +30,11 @@ describe('SupabaseService', () => {
 
   it('should throw error if SUPABASE_URL is missing', async () => {
     process.env.SUPABASE_URL = '';
+    process.env.SUPABASE_KEY = 'fake-key';
     await expect(
       Test.createTestingModule({
         imports: [ConfigModule],
-        providers: [SupabaseService],
+        providers: [SupabaseService, ConfigTestProvider],
       })
         .compile()
         .then((module) => {
@@ -43,11 +46,12 @@ describe('SupabaseService', () => {
   });
 
   it('should throw error if SUPABASE_KEY is missing', async () => {
+    process.env.SUPABASE_URL = 'https://fake-url.supabase.co';
     process.env.SUPABASE_KEY = '';
     await expect(
       Test.createTestingModule({
         imports: [ConfigModule],
-        providers: [SupabaseService],
+        providers: [SupabaseService, ConfigTestProvider],
       })
         .compile()
         .then((module) => {

--- a/test/imc/imc.controller.spec.ts
+++ b/test/imc/imc.controller.spec.ts
@@ -75,12 +75,16 @@ describe('ImcController', () => {
 
   // ========== History Tests ==========
 
-  it('should return IMC history for valid user', async () => {
+  it('should return IMC history for valid user without date filters', async () => {
+    // Arrange
     const user: User = fakeApplicationUser;
 
     jest.spyOn(service, 'getRecords').mockResolvedValue([]);
 
+    // Act
     const result = await controller.getHistory(user, {});
+
+    // Assert
     expect(result).toEqual([]);
     expect(service.getRecords).toHaveBeenCalledWith(
       user.id,
@@ -90,17 +94,20 @@ describe('ImcController', () => {
   });
 
   it('should return IMC history with date filters', async () => {
+    // Arrange
     const user: User = fakeApplicationUser;
     const from = new Date('2025-01-01');
     const to = new Date('2025-01-31');
 
     jest.spyOn(service, 'getRecords').mockResolvedValue([]);
 
+    // Act
     const result = await controller.getHistory(user, {
       startDate: from.toISOString(),
       endDate: to.toISOString(),
     });
 
+    // Assert
     expect(result).toEqual([]);
     expect(service.getRecords).toHaveBeenCalledWith(user.id, from, to);
   });
@@ -116,6 +123,7 @@ describe('ImcController', () => {
       transform: true,
     });
 
+    // Act
     await expect(
       validationPipe.transform(
         { startDate: invalidStartDate, endDate: invalidEndDate },
@@ -126,19 +134,22 @@ describe('ImcController', () => {
       ),
     ).rejects.toThrow(BadRequestException);
 
-    // Verificar que el servicio no se llama porque la validación falla antes
+    // Assert
     expect(service.getRecords).not.toHaveBeenCalled();
   });
 
   it('should throw BadRequestException if startDate is after endDate', async () => {
+    // Arrange
     const user: User = fakeApplicationUser;
     const startDate = '2025-02-01';
     const endDate = '2025-01-01';
 
     jest.spyOn(service, 'getRecords').mockResolvedValue([]);
 
+    // Act
     const result = controller.getHistory(user, { startDate, endDate });
 
+    // Assert
     await expect(result).rejects.toThrow(BadRequestException);
     expect(service.getRecords).not.toHaveBeenCalled();
   });

--- a/test/imc/imc.service.spec.ts
+++ b/test/imc/imc.service.spec.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -29,6 +30,7 @@ describe('ImcService', () => {
           provide: getRepositoryToken(Category),
           useClass: Repository,
         },
+        Logger,
       ],
     }).compile();
 

--- a/test/shared/providers/config-test.provider.ts
+++ b/test/shared/providers/config-test.provider.ts
@@ -2,5 +2,12 @@ import { ConfigService } from '@nestjs/config';
 
 export const ConfigTestProvider = {
   provide: ConfigService,
-  useValue: { get: jest.fn() },
+  useValue: {
+    get: jest.fn((key: string) => {
+      if (key === 'frontend') return { url: process.env.FRONTEND_URL };
+      if (key === 'supabase')
+        return { url: process.env.SUPABASE_URL, key: process.env.SUPABASE_KEY };
+      return undefined;
+    }),
+  },
 };


### PR DESCRIPTION
# ¿Qué se hizo?

- Se agregó un endpoint para consultar el historial de registros en función del usuario autenticado.
- Se agregó un método dentro del servicio del imc para recuperar los registros del usuario permitiendo enviar fechas para filtrar por un rango de tiempo específico.
- Se agregaron los tests correspondientes a los diferentes casos.